### PR TITLE
Added PHPUnit + tests for Native\Object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
-/vendor/
+/vendor
+/coverage
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -11,5 +11,13 @@
         "psr-4": {
             "Mysidia\\Resource\\": "src"
         }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "~4.0"
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Mysidia\\Resource\\Test\\": "tests"
+        }
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+    backupStaticAttributes="false"
+    bootstrap="vendor/autoload.php"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="false"
+    processIsolation="false"
+    stopOnFailure="true"
+    syntaxCheck="false"
+    >
+    <testsuites>
+        <testsuite>
+            <directory suffix=".php">tests</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist addUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/Native/Object.php
+++ b/src/Native/Object.php
@@ -6,20 +6,20 @@ namespace Mysidia\Resource\Native;
  * The Abstract Object Class, root of all Mysidia library files.
  * Contrary to Java's Object root class, this one is abstract.
  * For this reason, one cannot instantiate an object of this class.
+ *
  * @category  Resource
  * @package   Native
  * @author    Ordland
  * @copyright Mysidia RPG, Inc
  * @link      http://www.mysidiarpg.com
  * @abstract
- *
  */
 abstract class Object implements Objective
 {
     /**
      * Constructor of Object Class, which simply serves as a marker for child classes.
+     *
      * @access public
-     * @return Void
      */
     public function __construct()
     {
@@ -27,8 +27,8 @@ abstract class Object implements Objective
 
     /**
      * Destructor of Object Class, which simply serves as a marker for child classes.
+     *
      * @access public
-     * @return Void
      */
     public function __destruct()
     {
@@ -36,20 +36,23 @@ abstract class Object implements Objective
 
     /**
      * Magic method __clone() for Object Class, returns a copy of Object with additional operations.
+     *
      * @access public
+     *
      * @return Object
      */
     public function __clone()
     {
-        return clone $this;
+        return unserialize(serialize($this));
     }
 
     /**
      * The equals method, checks whether target object is equivalent to this one.
      *
+     * @access public
+     *
      * @param Objective $object
      *
-     * @access public
      * @return Boolean
      */
     public function equals(Objective $object)
@@ -59,8 +62,11 @@ abstract class Object implements Objective
 
     /**
      * The getClassName method, returns class name of an instance.
+     *
      * The return value may differ depending on child classes.
+     *
      * @access public
+     *
      * @return String
      */
     public function getClassName()
@@ -70,18 +76,23 @@ abstract class Object implements Objective
 
     /**
      * The hashCode method, returns the hash code for the very Object.
+     *
      * @access public
-     * @return Int
+     *
+     * @return float
      */
     public function hashCode()
     {
-        return hexdec(spl_object_hash($this));
+        return (float) hexdec(spl_object_hash($this));
     }
 
     /**
      * The serialize method, serializes an object into string format.
+     *
      * A serialized string can be stored in Constants, Database and Sessions.
+     *
      * @access public
+     *
      * @return String
      */
     public function serialize()
@@ -91,11 +102,13 @@ abstract class Object implements Objective
 
     /**
      * The unserialize method, decode a string to its object representation.
+     *
      * This method can be used to retrieve object info from Constants, Database and Sessions.
+     *
+     * @access public
      *
      * @param String $string
      *
-     * @access public
      * @return String
      */
     public function unserialize($string)
@@ -105,7 +118,9 @@ abstract class Object implements Objective
 
     /**
      * Magic method __toString() for Object class, returns object information.
+     *
      * @access public
+     *
      * @return String
      */
     public function __toString()

--- a/tests/Native/ObjectTest.php
+++ b/tests/Native/ObjectTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Mysidia\Resource\Test\Native;
+
+use Mysidia\Resource\Native\Object;
+use Mysidia\Resource\Test\Test;
+
+class ConcreteObject extends Object
+{
+}
+
+class ObjectTest extends Test
+{
+    /**
+     * @test
+     */
+    public function it_can_be_cloned()
+    {
+        $object = new ConcreteObject();
+
+        $clone = clone $object;
+
+        $this->assertInstanceOf(get_class($object), $clone);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_be_compared()
+    {
+        $firstObject = new ConcreteObject();
+
+        $secondObject = new ConcreteObject();
+
+        $this->assertTrue($firstObject->equals($secondObject));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_enhanced_class_name()
+    {
+        $object = new ConcreteObject();
+
+        $this->assertInstanceOf("Mysidia\\Resource\\Native\\String", $object->getClassName());
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_a_unique_hash_code()
+    {
+        $firstObject = new ConcreteObject();
+
+        $firstHash = $firstObject->hashCode();
+
+        $this->assertInternalType("float", $firstHash);
+
+        $secondObject = new ConcreteObject();
+
+        $secondHash = $secondObject->hashCode();
+
+        $this->assertNotEquals($firstHash, $secondHash);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_be_serialized_and_unserialized()
+    {
+        $object = new ConcreteObject();
+
+        $serialized = serialize($object);
+
+        $this->assertInternalType("string", $serialized);
+
+        $unserialized = unserialize($serialized);
+
+        $this->assertEquals($object, $unserialized);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_be_cast_to_string()
+    {
+        $object = new ConcreteObject();
+
+        $this->assertInternalType("string", (string) $object);
+    }
+}

--- a/tests/Test.php
+++ b/tests/Test.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Mysidia\Resource\Test;
+
+use PHPUnit_Framework_TestCase;
+
+/**
+ * This is a hook for future cross-cutting concerns.
+ *
+ * @category  Resource
+ * @package   Native
+ * @author    Christopher Pitt <cgpitt@gmail.com>
+ * @copyright Mysidia RPG, Inc
+ * @link      http://www.mysidiarpg.com
+ * @abstract
+ */
+abstract class Test extends PHPUnit_Framework_TestCase
+{
+}


### PR DESCRIPTION
Added PHPUnit + the first batch of tests. I made 2 small changes to the original class:

1. The class was calling `clone` inside the `__clone` method; which was causing a stack overflow. I replaced that with `unserialize(serialize($this))` as it does much the same thing. 
2. The class used to return either `int`or `float` [depending on what `hexdec` felt like doing at the time]. I am now coercing this to a float so the sake of simplicity.