### PR TITLE
Added Mockery + tests for Native\Arrays

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0"
+        "phpunit/phpunit": "~4.0",
+        "mockery/mockery": "~0.8"
     },
     "autoload-dev": {
         "psr-4": {

--- a/src/Native/Arrays.php
+++ b/src/Native/Arrays.php
@@ -7,8 +7,10 @@ use Exception;
 use SplFixedArray;
 
 /**
- * The Arrays Class, extending from SplFixedArray class
+ * The Arrays Class, extending from SplFixedArray class.
+ *
  * It defines how fixed sized numeric arrays are used in Mysidia Adoptables.
+ *
  * @category  Resource
  * @package   Native
  * @author    Ordland
@@ -22,10 +24,13 @@ final class Arrays extends SplFixedArray implements Objective
     /**
      * The equals method, checks whether target array is equivalent to this one.
      *
-     * @param Arrays $array
-     *
      * @access public
-     * @return Boolean
+     *
+     * @param Objective $array
+     *
+     * @return bool
+     *
+     * @throws Exception
      */
     public function equals(Objective $array)
     {
@@ -38,18 +43,22 @@ final class Arrays extends SplFixedArray implements Objective
 
     /**
      * Magic method __clone() for Arrays Class, returns a copy of the array.
+     *
      * @access public
+     *
      * @return Arrays
      */
     public function __clone()
     {
-        return clone $this;
+        return unserialize(serialize($this));
     }
 
     /**
      * The serialize method, serializes an array into string format.
+     *
      * @access public
-     * @return String
+     *
+     * @return string
      */
     public function serialize()
     {
@@ -58,12 +67,14 @@ final class Arrays extends SplFixedArray implements Objective
 
     /**
      * The unserialize method, decode a string to its object representation.
+     *
      * This method can be used to retrieve object info from Constants, Database and Sessions.
      *
-     * @param String $string
-     *
      * @access public
-     * @return Arrays
+     *
+     * @param string $string
+     *
+     * @return $this
      */
     public function unserialize($string)
     {
@@ -72,8 +83,10 @@ final class Arrays extends SplFixedArray implements Objective
 
     /**
      * The length method, returns the size of the array in java way.
+     *
      * @access public
-     * @return Int
+     *
+     * @return int
      */
     public function length()
     {
@@ -82,7 +95,9 @@ final class Arrays extends SplFixedArray implements Objective
 
     /**
      * The iterator method, retrieves an ArrayIterator for this Array.
+     *
      * @access public
+     *
      * @return ArrayIterator
      */
     public function iterator()
@@ -92,21 +107,25 @@ final class Arrays extends SplFixedArray implements Objective
 
     /**
      * The getClassName method, acquires the class name as Array.
+     *
      * @access public
+     *
      * @return String
      */
     public function getClassName()
     {
-        return "Array";
+        return new String(get_class($this));
     }
 
     /**
      * Magic method to_String() for Arrays class, returns basic array information.
+     *
      * @access public
-     * @return String
+     *
+     * @return string
      */
     public function __toString()
     {
-        return "Array({$this->length()})";
+        return get_class($this)."(".$this->length().")";
     }
 }

--- a/tests/Native/ArraysTest.php
+++ b/tests/Native/ArraysTest.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Mysidia\Resource\Test\Native;
+
+use Exception;
+use Mockery;
+use Mysidia\Resource\Native\Arrays;
+use Mysidia\Resource\Native\Objective;
+use Mysidia\Resource\Test\Test;
+
+class ConcreteObjective implements Objective
+{
+    public function serialize()
+    {
+        // stub method
+    }
+
+    public function unserialize($serialized)
+    {
+        // stub method
+    }
+
+    public function equals(Objective $object)
+    {
+        // stub method
+    }
+
+    public function getClassName()
+    {
+        // stub method
+    }
+
+    public function __clone()
+    {
+        // stub method
+    }
+
+    public function __toString()
+    {
+        // stub method
+
+        return "";
+}}
+
+class ArraysTest extends Test
+{
+    /**
+     * @test
+     */
+    public function it_can_be_cloned()
+    {
+        $arrays = new Arrays();
+
+        $clone = clone $arrays;
+
+        $this->assertInstanceOf(get_class($arrays), $clone);
+    }
+
+    /**
+     * @test
+     *
+     * @expectedException Exception
+     */
+    public function it_throws_for_invalid_arguments()
+    {
+        $arrays = new Arrays();
+
+        $objective = new ConcreteObjective();
+
+        $this->assertTrue($arrays->equals($objective));
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_be_compared()
+    {
+        $firstArrays = new Arrays();
+
+        $secondArrays = new Arrays();
+
+        $this->assertTrue($firstArrays->equals($secondArrays));
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_return_length()
+    {
+        $arrays = new Arrays(3);
+
+        $this->assertEquals(3, $arrays->length());
+    }
+
+    /**
+     * @test
+     */
+    public function it_acn_return_an_iterator()
+    {
+        $arrays = new Arrays();
+
+        $this->assertInstanceOf("Iterator", $arrays->iterator());
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_enhanced_class_name()
+    {
+        $arrays = new Arrays();
+
+        $this->assertInstanceOf("Mysidia\\Resource\\Native\\String", $arrays->getClassName());
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_be_serialized_and_unserialized()
+    {
+        $arrays = new Arrays();
+
+        $serialized = serialize($arrays);
+
+        $this->assertInternalType("string", $serialized);
+
+        $unserialized = unserialize($serialized);
+
+        $this->assertEquals($arrays, $unserialized);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_be_cast_to_string()
+    {
+        $arrays = new Arrays();
+
+        $this->assertInternalType("string", (string) $arrays);
+    }
+}

--- a/tests/Test.php
+++ b/tests/Test.php
@@ -2,6 +2,7 @@
 
 namespace Mysidia\Resource\Test;
 
+use Mockery;
 use PHPUnit_Framework_TestCase;
 
 /**
@@ -16,4 +17,10 @@ use PHPUnit_Framework_TestCase;
  */
 abstract class Test extends PHPUnit_Framework_TestCase
 {
+    protected function tearDown()
+    {
+        parent::tearDown();
+
+        Mockery::close();
+    }
 }


### PR DESCRIPTION
This required the same change to `__clone` as with `Native\Object`. I also re-implemented `__toString` and `getClassName` to be consistent with `Native\Object`.